### PR TITLE
Cicd fix

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -57,7 +57,10 @@ jobs:
       uses: benjefferies/branch-protection-bot@master
       if: always()
       with:
-          access-token: ${{ secrets.ACCESS_TOKEN }}
+          access_token: ${{ secrets.ACCESS_TOKEN }}
+          branch: main
+          enforce_admins: false
+
 
     # Step 4. Use PSR to make release
     - name: Python Semantic Release
@@ -72,9 +75,9 @@ jobs:
       uses: benjefferies/branch-protection-bot@master
       if: always()  # Force to always run this step to ensure "include administrators" is always turned back on
       with:
-        access-token: ${{ secrets.ACCESS_TOKEN }}
-        owner: UBC-MDS
-        repo: pytextprep
+        access_token: ${{ secrets.ACCESS_TOKEN }}
+        branch: main
+        enforce_admins: true
 
     # Step 5. Publish to TestPyPI
     - uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Last CICD run failed due to wrong parameter passed to the branch-protection-bot
Here we could try again after updating the parameters 